### PR TITLE
fix: 图片放大时加载微信原图，去除 640 尺寸限制

### DIFF
--- a/src/reader.content/imageViewer.ts
+++ b/src/reader.content/imageViewer.ts
@@ -76,6 +76,27 @@ export function initImageViewer(): void {
 }
 
 /**
+ * 去除微信图床 URL 末尾的尺寸限制，返回原图地址
+ *
+ * 微信图片 URL 形如：
+ *   https://mmbiz.qpic.cn/mmbiz_png/XXXX/640?from=appmsg#imgIndex=1
+ * 路径末尾的数字（如 640）是微信的分辨率标记，会返回被裁切/压缩的图。
+ * 微信约定用 0 表示不限制尺寸的原图，因此将末尾尺寸段替换为 0，
+ * medium-zoom 加载这张原图后会按其真实尺寸计算放大比例。
+ *
+ * @param url 原始图片 URL
+ * @returns 去除尺寸限制后的 URL；非微信图床或格式不匹配时原样返回
+ */
+function stripWeChatImageSizeLimit(url: string): string {
+  if (!url || !url.includes(`mmbiz.qpic.cn`)) {
+    return url
+  }
+  // 匹配路径最后一段的纯数字尺寸标记，锚定在 ? / # / 字符串结尾之前，
+  // 避免误伤路径中间的其它数字段。已是 0 时正则同样匹配，替换后结果不变。
+  return url.replace(/\/\d+(?=[?#]|$)/, `/0`)
+}
+
+/**
  * 处理文章中的所有图片，为其添加缩放属性
  */
 function processArticleImages(): void {
@@ -108,11 +129,13 @@ function prepareImageForZoom(img: HTMLImageElement): void {
     return
   }
 
-  // 优先使用data-src属性（通常包含原始图片URL）
-  const dataSrc = img.getAttribute(`data-src`)
-  if (dataSrc) {
-    // 设置data-zoom-src属性，medium-zoom将使用它作为缩放时的图片源
-    img.setAttribute(`data-zoom-src`, dataSrc)
+  // 解析原图 URL：优先 data-src（微信懒加载常把原图放这里），其次当前 src，
+  // 并去除微信图床末尾的 640 等尺寸限制，换成 /0 原图
+  const rawSrc = img.getAttribute(`data-src`) || img.src
+  const originalSrc = stripWeChatImageSizeLimit(rawSrc)
+  if (originalSrc) {
+    // 设置 data-zoom-src，medium-zoom 放大时会加载这张原图作为高清源
+    img.setAttribute(`data-zoom-src`, originalSrc)
   }
 
   // 标记为已处理


### PR DESCRIPTION
## 问题

点击文章图片放大预览时，`data-zoom-src` 直接使用了带 `/640` 尺寸标记的微信图床 URL，例如：

```
https://mmbiz.qpic.cn/mmbiz_png/XXXX/640?from=appmsg#imgIndex=1
```

`/640` 是微信图床的分辨率标记，返回的是被压缩裁切的图。因此 medium-zoom 放大时加载的仍是低清缩略图，放大后清晰度不佳。

## 改动

在 `src/reader.content/imageViewer.ts` 中新增 `stripWeChatImageSizeLimit()`，将微信图床 URL 末尾的尺寸段替换为 `/0`（微信约定的原图不限制标记）。medium-zoom 内置的 HD 机制（`data-zoom-src`）会加载这张原图，并按其真实尺寸重新计算放大比例，从而提升放大清晰度。

同时在图片无 `data-src` 时回退到当前 `src`，保证所有文章图片都能拿到高清源。

- 仅微信图床（`mmbiz.qpic.cn`）URL 会被处理，其它域名原样返回，不误伤
- URL 已是 `/0` 时替换后结果不变，幂等
- 正则锚定在 `?` / `#` / 结尾之前，避免误伤路径中间的数字段

## 验证

- `pnpm build` 构建通过
- `pnpm lint` 无新增告警
- 对多种 URL 形态做了替换逻辑自测（带参数 / 无参数 / 已是 0 / 非微信域名）
- 本地加载扩展，公众号文章图片放大后加载的是 `/0` 原图，清晰度提升

## 已知边界

medium-zoom 计算放大比例时有 `Math.min(scale, viewportWidth/width)` 约束，放大上限为“填满视口”。对于远大于视口的超大图，仍会被缩放到视口内显示，无法 1:1 查看局部细节。本 PR 聚焦于“加载原图、提升清晰度”，不改变 medium-zoom 的视口贴合交互范式。